### PR TITLE
bug(ticket): fix ticketrolestatusenum bug

### DIFF
--- a/migrations/versions/09cb109bfdf2_.py
+++ b/migrations/versions/09cb109bfdf2_.py
@@ -164,6 +164,7 @@ def downgrade():
                         ['airplane.id'],
                         name='flight_airplane_id_fkey'),
                     sa.PrimaryKeyConstraint('id', name='pk_flight'))
+    op.execute("drop type ticketstatusenum CASCADE")
     op.drop_table('tickets')
     op.drop_table('flights')
     op.drop_table('airplanes')


### PR DESCRIPTION
**What does this PR do?**
This PR applies the fix to the `type "ticketstatusenum" already exists` bug that stops an engineer from upgrading after they've downgraded to the base.

**Commit message**
- delete the enum when the table is downgraded

[Fixes #166628101]

**PivotalTracker story**
[#166628101](https://www.pivotaltracker.com/story/show/166628101)